### PR TITLE
Fix: Sort query parameter names in canonical query string

### DIFF
--- a/AmazonTranscribeStreamingClient/Models/Config.cs
+++ b/AmazonTranscribeStreamingClient/Models/Config.cs
@@ -25,7 +25,7 @@ namespace Amazon.TranscribeStreamingService.Models {
         public string? VocabularyNames { get; set; }
         public string? VocabularyFilterNames { get; set; }
 
-        public Config(string language, string mediaEncoding, string sampleRate) {
+        public Config(string mediaEncoding, string sampleRate, string? Language) {
             this.Language = language;
             this.MediaEncoding = mediaEncoding;
             this.SampleRate = sampleRate;
@@ -33,7 +33,7 @@ namespace Amazon.TranscribeStreamingService.Models {
 
         public SortedDictionary<string, string> GetDictionary() {
             SortedDictionary<string, string> dict = new SortedDictionary<string, string>();
-            dict.Add("language-code",this.Language);
+            if(!string.IsNullOrEmpty(this.Language)) dict.Add("language-code",this.Language);
             dict.Add("media-encoding",this.MediaEncoding);
             dict.Add("sample-rate",this.SampleRate);
             if(!string.IsNullOrEmpty(this.VocabularyName)) dict.Add("vocabulary-name", this.VocabularyName);

--- a/AmazonTranscribeStreamingClient/Models/Config.cs
+++ b/AmazonTranscribeStreamingClient/Models/Config.cs
@@ -3,7 +3,7 @@
 
 namespace Amazon.TranscribeStreamingService.Models {
     public class Config {
-        public string Language;
+        public string? Language;
         public string MediaEncoding;
         public string SampleRate;
         public string? VocabularyName { get; set; }
@@ -31,8 +31,8 @@ namespace Amazon.TranscribeStreamingService.Models {
             this.SampleRate = sampleRate;
         }
 
-        public Dictionary<string, string> GetDictionary() {
-            Dictionary<string, string> dict = new Dictionary<string, string>();
+        public SortedDictionary<string, string> GetDictionary() {
+            SortedDictionary<string, string> dict = new SortedDictionary<string, string>();
             dict.Add("language-code",this.Language);
             dict.Add("media-encoding",this.MediaEncoding);
             dict.Add("sample-rate",this.SampleRate);

--- a/AmazonTranscribeStreamingClient/Models/Config.cs
+++ b/AmazonTranscribeStreamingClient/Models/Config.cs
@@ -25,8 +25,13 @@ namespace Amazon.TranscribeStreamingService.Models {
         public string? VocabularyNames { get; set; }
         public string? VocabularyFilterNames { get; set; }
 
-        public Config(string mediaEncoding, string sampleRate, string? Language) {
-            this.Language = language;
+        public Config(string mediaEncoding, string sampleRate) {
+            this.MediaEncoding = mediaEncoding;
+            this.SampleRate = sampleRate;
+        }
+
+        public Config(string mediaEncoding, string sampleRate, string language) {
+            this.Language = language
             this.MediaEncoding = mediaEncoding;
             this.SampleRate = sampleRate;
         }


### PR DESCRIPTION
*Issue #, if available:*
InvalidSignatureException error caused by query parameters not in sorted (ascending) order.

*Description of changes:*
Changed Config.cs to 1/ replace Dictionary with SortedDictionary.  2/ Made Language code optional field (when using automatic language identification, Transcribe API does not expect language-code parameter in the request). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
