### PR TITLE
Fix StreamBuffer

### DIFF
--- a/AmazonTranscribeStreamingClient/AmazonTranscribeStreamingClient.cs
+++ b/AmazonTranscribeStreamingClient/AmazonTranscribeStreamingClient.cs
@@ -144,7 +144,7 @@ namespace Amazon.TranscribeStreamingService
       {
         AudioEvent audioEvent = new AudioEvent(buffer);
         byte[] eventBuffer = audioEvent.Serialize();
-        _client.Send(buffer);
+        _client.Send(eventBuffer);
       }
       else
       {


### PR DESCRIPTION

*Description of changes:*

in AmazonTranscribeStreamingClient.cs, in the method StreamBuffer(byte[])
     send the serialized version of the buffer (eventBuffer), instead of buffer.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
