### PR TITLE
Fix PreferredLanguage in config.

### DIFF
--- a/AmazonTranscribeStreamingClient/Models/Config.cs
+++ b/AmazonTranscribeStreamingClient/Models/Config.cs
@@ -31,7 +31,7 @@ namespace Amazon.TranscribeStreamingService.Models {
         }
 
         public Config(string mediaEncoding, string sampleRate, string language) {
-            this.Language = language
+            this.Language = language;
             this.MediaEncoding = mediaEncoding;
             this.SampleRate = sampleRate;
         }
@@ -56,6 +56,7 @@ namespace Amazon.TranscribeStreamingService.Models {
             if(!string.IsNullOrEmpty(this.LanguageModelName)) dict.Add("language-model-name", this.LanguageModelName);
             if(!string.IsNullOrEmpty(this.IdentifyLanguage)) dict.Add("identify-language", this.IdentifyLanguage);
             if(!string.IsNullOrEmpty(this.LanguageOptions)) dict.Add("language-options", this.LanguageOptions);
+            if(!string.IsNullOrEmpty(this.PreferredLanguage)) dict.Add("preferred-language", this.PreferredLanguage);
             if(!string.IsNullOrEmpty(this.VocabularyNames)) dict.Add("vocabulary-names", this.VocabularyNames);
             if(!string.IsNullOrEmpty(this.VocabularyFilterNames)) dict.Add("vocabulary-filter-names", this.VocabularyFilterNames);
 


### PR DESCRIPTION
This option could be set in the object, but wasn't passed down to the canonical string being built.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.