### PR TITLE
fix: adds security token to query params

### DIFF
--- a/AmazonTranscribeStreamingClient/TranscribePresignedUrl.cs
+++ b/AmazonTranscribeStreamingClient/TranscribePresignedUrl.cs
@@ -62,7 +62,7 @@ namespace Amazon.TranscribeStreamingService {
                 {"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
                 {"X-Amz-Credential", credentials},
                 {"X-Amz-Date", dateTimeString},
-                {"X-Amz-Expires", "300"},
+                {"X-Amz-Expires", "30"},
                 {"X-Amz-Security-Token", securityToken},
                 {"X-Amz-SignedHeaders", "host"}
             };

--- a/AmazonTranscribeStreamingClient/TranscribePresignedUrl.cs
+++ b/AmazonTranscribeStreamingClient/TranscribePresignedUrl.cs
@@ -56,12 +56,14 @@ namespace Amazon.TranscribeStreamingService {
         private string GenerateQueryParams(string dateTimeString, string credentialScope)
         {
             var credentials = $"{ _credentials.GetCredentials().AccessKey}/{credentialScope}";
+            var securityToken = _credentials.GetCredentials().Token;
             var result = new Dictionary<string, string>
             {
                 {"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
                 {"X-Amz-Credential", credentials},
                 {"X-Amz-Date", dateTimeString},
-                {"X-Amz-Expires", "30"},
+                {"X-Amz-Expires", "300"},
+                {"X-Amz-Security-Token", securityToken},
                 {"X-Amz-SignedHeaders", "host"}
             };
             result.Update(_config.GetDictionary());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added X-Amz-Security-Token to resolve the PresignedUrl not having the correct authorization.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
